### PR TITLE
Allow sorting of nested fields using property-expr

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/radubrehar/sorty/issues"
   },
   "homepage": "https://github.com/radubrehar/sorty",
+  "dependencies": {
+    "property-expr": "^1.3.1"
+  },
   "devDependencies": {
     "mocha": "^2.0.1",
     "should": "^4.3.0"

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 var curry = require('./curry')
 var TYPES = require('./types')
+var expr = require('property-expr');
 
 function isFn(fn){
     return typeof fn === 'function'
@@ -20,6 +21,8 @@ var getSingleSortFunction = function(info){
     }
 
     var field = info.name
+    var getter = expr.getter(field, true)
+
     var dir   = info.dir === 'desc' || info.dir < 0?
                     -1:
                     info.dir === 'asc' || info.dir > 0?
@@ -41,8 +44,8 @@ var getSingleSortFunction = function(info){
     var fn = info.fn
 
     return function(first, second){
-        var a = first[field]
-        var b = second[field]
+        var a = getter(first)
+        var b = getter(second)
 
         return dir * fn(a, b)
     }

--- a/test/main.js
+++ b/test/main.js
@@ -23,6 +23,27 @@ describe('test all', function(){
         ])
     })
 
+    it('should sort nested objects', function(){
+        var arr = [
+            {user: {name: 'john', age: 20}},
+            {user: {name: 'mary', age: 10}},
+            {user: {name: 'bill', age: 40}},
+            {user: {name: 'john', age: 100}}
+        ]
+
+        sorty([
+            {name: 'user.name', dir: 'asc'},
+            {name: 'user.age',  dir: 'desc', type: 'number'}
+        ], arr)
+
+        arr.should.eql([
+            {user: {name: 'bill', age: 40}},
+            {user: {name: 'john', age: 100}},
+            {user: {name: 'john', age: 20}},
+            {user: {name: 'mary', age: 10}}
+        ])
+    })
+
     it('should sort with custom fn', function(){
         var arr = [
             { age: '5', name: 'mary'},


### PR DESCRIPTION
Hi!

I needed to sort a large dataset of nested objects. Rather than transform each record into a flat structure it was easier to patch sorty to support nested property names (like mongodb).

Just sending this pull request incase it is useful to more people!

Cheers,
~ Simon